### PR TITLE
use same syllable for sigil as mobile

### DIFF
--- a/src/js/components/lib/icons/sigil.js
+++ b/src/js/components/lib/icons/sigil.js
@@ -3,10 +3,10 @@ import { sealDict } from '/components/lib/seal-dict';
 
 export class Sigil extends Component {
   render() {
-    let suffix = this.props.suffix ? JSON.parse(this.props.suffix) : false;
+    let prefix = this.props.prefix ? JSON.parse(this.props.prefix) : false;
 
     return (
-      sealDict.getSeal(this.props.ship.substr(1), this.props.size, suffix)
+      sealDict.getSeal(this.props.ship.substr(1), this.props.size, prefix)
     )
   }
 }

--- a/src/js/components/lib/seal-dict.js
+++ b/src/js/components/lib/seal-dict.js
@@ -66,12 +66,12 @@ export class SealDict {
     this.dict = {};
   }
 
-  getSuffix(patp) {
-    return patp.length === 3 ? patp : patp.substr(-3, 3);
+  getPrefix(patp) {
+    return patp.length === 3 ? patp : patp.substr(0, 3);
   }
 
-  getSeal(patp, size, suffix) {
-    let sigilShip = suffix ? this.getSuffix(patp) : patp;
+  getSeal(patp, size, prefix) {
+    let sigilShip = prefix ? this.getPrefix(patp) : patp;
     let key = `${sigilShip}+${size}`;
 
     if (!this.dict[key]) {


### PR DESCRIPTION
Use the first syllable sigil for chat, etc.