### PR TITLE
Implement mobile-friendly design

### DIFF
--- a/src/css/pages/command.css
+++ b/src/css/pages/command.css
@@ -16,11 +16,6 @@
   margin-bottom: 27px;
 }
 
-.command-options, .command-input-placeholder-wrapper {
-  margin-left: -9px;
-  width: calc(100% + 9px);
-}
-
 input.command-menu-input, .command-input-placeholder-wrapper {
   position: relative;
   border: none;

--- a/src/css/pages/profile.css
+++ b/src/css/pages/profile.css
@@ -20,3 +20,10 @@
 .profile-qr-desc {
   max-width: 256px;
 }
+
+.profile-avatar {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/css/pages/profile.css
+++ b/src/css/pages/profile.css
@@ -21,9 +21,11 @@
   max-width: 256px;
 }
 
-.profile-avatar {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
+@media all and (max-width: 415px) {
+  .profile-avatar {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/src/js/components/command.js
+++ b/src/js/components/command.js
@@ -453,7 +453,6 @@ export class CommandMenu extends Component {
           storeReports={this.props.storeReports}
         />
         <div className="row command-row">
-          <div className="flex-col-1"></div>
           <div className="flex-col-1 justify-start" onClick={this.closeMenu}>
             <Icon type="icon-x" />
           </div>
@@ -473,8 +472,7 @@ export class CommandMenu extends Component {
           </div>
         </div>
         <div className="row">
-          <div className="flex-col-2"></div>
-          <div className="flex-col-x command-options">
+          <div className="flex-offset-1 flex-col-x command-options">
             {view}
           </div>
         </div>

--- a/src/js/components/header.js
+++ b/src/js/components/header.js
@@ -214,8 +214,7 @@ export class Header extends Component {
         });
         return (
           <React.Fragment>
-            <div className="flex-col-2"></div>
-            <div className="flex-col-x text-heading text-squat">
+            <div className="flex-col-x flex-offset-1 text-heading text-squat">
               <a className={recentClass} onClick={() => { this.navigateSubpage('inbox', 'inbox-recent') }}>Recent</a>
               <a className={listClass} onClick={() => { this.navigateSubpage('inbox', 'inbox-list') }}>All</a>
             </div>
@@ -239,7 +238,6 @@ export class Header extends Component {
 
         return (
           <React.Fragment>
-            <div className="flex-col-2"></div>
             <div className="flex-col-x">
               {authorElem}
               <span className="text-mono text-300 text-small">{this.props.data.dateCreated.slice(0, -6)}</span>
@@ -262,8 +260,7 @@ export class Header extends Component {
         });
         return (
           <React.Fragment>
-            <div className="flex-col-2"></div>
-            <div className="flex-col-x text-heading text-squat">
+            <div className="flex-col-x flex-offset-1 text-heading text-squat">
               <a className={indexClass} href={`/~~/${this.props.data.author}/==/web/landscape/profile`}>Profile</a>
               {this.props.data.author.substr(1) === this.props.api.authTokens.ship &&
                 <a className={settingsClass} href={`/~~/${this.props.data.author}/==/web/landscape/profile/settings`}>Settings</a>
@@ -361,19 +358,20 @@ export class Header extends Component {
     return (
       <div className="container header-container">
         <div className="row">
-          <div className="flex-col-2"></div>
-          <div className="flex-col-x header-breadcrumbs">
+          <div className="flex-offset-1 flex-col-x header-breadcrumbs">
             {breadcrumbsElem}
           </div>
         </div>
-        <div className="row align-center header-mainrow">
+        <div className="row align-center">
           <div className="flex-col-1 flex justify-end">
             <HeaderNotification
               notifications={this.props.store.messages.notifications}
               pushCallback={this.props.pushCallback}
             />
           </div>
-          <div className="flex-col-1 flex space-between align-center">
+        </div>
+        <div className="row align-center header-mainrow">
+         <div className="flex-col-1 flex space-between align-center">
             <a onClick={this.toggleMenu}>
               <Icon type="icon-panini" />
             </a>

--- a/src/js/components/inbox/all.js
+++ b/src/js/components/inbox/all.js
@@ -32,7 +32,7 @@ export class InboxAllPage extends Component {
 
       return (
         <div key={stationDetails.station} className="mt-3 row align-center">
-          <div className="text-mono flex-col-3 flex-offset-2">
+          <div className="text-mono flex-col-3 flex-offset-1">
             {stationDetails.type !== "stream-dm" &&
               <React.Fragment>
                 <a className="text-host-breadcrumb" href={stationDetails.hostProfileUrl}>
@@ -83,7 +83,7 @@ export class InboxAllPage extends Component {
       return (
         <div className="mt-4 mb-17">
           <div className="row">
-            <div className="flex-col-2 flex justify-end align-center">
+            <div className="flex-col-1 flex justify-end align-center">
               <Icon type={s.icon} label={true} />
             </div>
             <div className="flex-col-x">

--- a/src/js/components/inbox/recent.js
+++ b/src/js/components/inbox/recent.js
@@ -88,7 +88,7 @@ export class InboxRecentPage extends Component {
                     <Icon type='icon-collection-post' label={true}/>
                   }
                 </div>
-                <div className="flex-col-x">
+                <div className="flex-offset-1 flex-col-x">
                   {messageDetails.postUrl &&
                     <a className="text-heading text-500"
                       href={messageDetails.postUrl}>
@@ -99,8 +99,7 @@ export class InboxRecentPage extends Component {
                 <div className="flex-col-3"></div>
               </div>
               <div className="row">
-                <div className="flex-col-2"></div>
-                <div className={`flex-col-x ${isPostUpdate ? 'mt-1' : 'mt-3'}`}>
+                <div className={`flex-offset-1 flex-col-x ${isPostUpdate ? 'mt-1' : 'mt-3'}`}>
                   <a className="vanilla text-mono text-small text-700" href={prettyShip(msg.aut)[1]}>{prettyShip(`~${msg.aut}`)[0]}</a>
                 </div>
                 <div className="flex-col-3"></div>
@@ -108,8 +107,7 @@ export class InboxRecentPage extends Component {
             </React.Fragment>
           }
           <div className="row">
-            <div className="flex-col-2"></div>
-            <div className="flex-col-x">
+            <div className="flex-offset-1 flex-col-x">
               <Message details={messageDetails} api={this.props.api} storeReports={this.props.storeReports} pushCallback={this.props.pushCallback} transitionTo={this.props.transitionTo}></Message>
             </div>
             <div className="flex-col-3"></div>
@@ -135,8 +133,7 @@ export class InboxRecentPage extends Component {
         <div className="mt-4 mb-6" key={i}>
           {section.stationDetails.type !== "stream-dm" &&
             <div className="row">
-              <div className="flex-col-2"></div>
-              <div className="flex-col-x">
+              <div className="flex-offset-1 flex-col-x">
                 <a href={section.stationDetails.hostProfileUrl} className="text-host-breadcrumb">~{section.stationDetails.host}</a>
                 <span className="text-host-breadcrumb ml-2 mr-2">/</span>
               </div>
@@ -144,7 +141,7 @@ export class InboxRecentPage extends Component {
             </div>
           }
           <div className="row align-center">
-            <div className="flex-col-2 flex justify-end">
+            <div className="flex-col-1 flex justify-end">
               <Icon type={section.icon} label={true}/>
             </div>
             <div className="flex-col-x">
@@ -271,7 +268,7 @@ export class InboxRecentPage extends Component {
       <React.Fragment>
         {invites.length > 0 &&
           <div className="row mt-3">
-            <div className="flex-offset-2 flex-col-x">
+            <div className="flex-offset-1 flex-col-x">
               <h3 className="mb-1">Invites</h3>
             </div>
           </div>

--- a/src/js/components/lib/page-status.js
+++ b/src/js/components/lib/page-status.js
@@ -29,7 +29,7 @@ export class PageStatus extends Component {
     return (
       <React.Fragment>
         {this.props.transition !== PAGE_STATUS_READY &&
-          <div className="header-pending-panel text-small row flex-offset-1">
+          <div className="header-pending-panel text-small row">
             <div onClick={this.pendingAction} className={loadingClass}></div>
             {this.props.transition === PAGE_STATUS_DISCONNECTED &&
               <span>Connection to <span className="text-mono">~{this.props.usership}</span> failed</span>

--- a/src/js/components/root.js
+++ b/src/js/components/root.js
@@ -146,7 +146,6 @@ export class Root extends Component {
       <div>
         <div className="container header-container">
           <div className="row">
-            <div className="flex-col-2"></div>
             <div className="flex-col-x header-breadcrumbs"></div>
           </div>
           <div className="row align-center header-mainrow">

--- a/src/js/components/stream/chat.js
+++ b/src/js/components/stream/chat.js
@@ -331,7 +331,7 @@ export class ChatPage extends Component {
            data-date-group={msg.dateGroup}
            onMouseEnter={this.mouseenterActivate}
            onMouseLeave={this.mouseleaveActivate}>
-        <div className="flex-col-2 flex align-center justify-end">
+        <div className="flex-col-1 flex align-center justify-end">
           {msg.printship &&
             <a className="vanilla chat-sigil" href={prettyShip(msg.aut)[1]}>
               {sealDict.getSeal(msg.aut, 18, true)}
@@ -389,7 +389,7 @@ export class ChatPage extends Component {
           {chatMessages}
         </Scrollbars>
         <div className="row mt-3 flex-chat-input">
-          <div className="flex-col-2 flex justify-end">
+          <div className="flex-col-1 flex justify-end">
             <a className="vanilla chat-sigil" href={prettyShip(api.authTokens.ship)[1]}>
               {sealDict.getSeal(api.authTokens.ship, 18, true)}
             </a>

--- a/urbit-code/web/landscape/profile.hoon
+++ b/urbit-code/web/landscape/profile.hoon
@@ -11,7 +11,7 @@
   ;input(type "hidden", name "urb-metadata", urb-structure-type "header-profile", urb-author "{(scow %p p.bem.gas)}");
   ;div.container
     ;div.row
-      ;div.flex-col-2;
+      ;div.flex-col-1;
       ;div.flex-col-x
         ;div.profile-avatar
           ;div(urb-component "Sigil", urb-size "320", urb-ship "{(scow %p p.bem.gas)}", urb-suffix "false");
@@ -20,17 +20,17 @@
       ==
     ==
     ;div.row.mt-9
-      ;div.flex-offset-2.flex-col-x
+      ;div.flex-offset-1.flex-col-x
         ;h2.text-500: Meta
       ==
     ==
     ;div.row.mt-4.align-center
-      ;div.flex-col-2;
+      ;div.flex-col-1;
       ;h3.text-500.flex-col-1.mt-0: Started:
       ;div.flex-col-x.text-mono: ~2018.4.12..6.45.12
     ==
     ;div.row.mt-3.align-center
-      ;div.flex-col-2;
+      ;div.flex-col-1;
       ;h3.text-500.flex-col-1.mt-0: Issued:
       ;div.flex-col-x
         ;a.text-mono(href "/~~/{(scow %p (^sein:title p.bem.gas))}/==/web/landscape/profile"): {(scow %p (^sein:title p.bem.gas))}

--- a/urbit-code/web/landscape/profile/settings.hoon
+++ b/urbit-code/web/landscape/profile/settings.hoon
@@ -13,7 +13,7 @@
   ;input(type "hidden", name "urb-metadata", urb-structure-type "header-profile", urb-author "{(scow %p p.bem.gas)}");
   ;div.container(urb-devices "")
     ;div.row.mt-4
-      ;div.flex-col-2;
+      ;div.flex-col-1;
       ;div.flex-col-x
         ;a.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-devices]")[0].classList.add("hide"); document.querySelectorAll("[urb-qr]")[0].classList.remove("hide");})()')): Connect device
         ;div.mt-6
@@ -24,7 +24,7 @@
   ==
   ;div.container.hide(urb-qr "")
     ;div.row.mt-4
-      ;div.flex-col-2;
+      ;div.flex-col-1;
       ;div.flex-col-x
         ;div
           =urb-component  "QRCodeComponent"


### PR DESCRIPTION
By manipulating the flex-grid offsets slightly we can get a mobile-friendly
design without changing the structure much at all.

Mostly this patch removes some empty divs that were used for spacing. Empty divs
really shouldn't be used for layout anyway.

On mobile, the end result is a usable interface where all the elements are
accessible. On desktop, the end result is that the app is slightly more
left-aligned, which I think is a fair trade-off. Everything else seems correctly
aligned as before.

The only thing I didn't get to test was the Forum, which I don't know how to
use.