### PR TITLE
ship.arvo.network router fix

### DIFF
--- a/src/js/components/lib/page-status.js
+++ b/src/js/components/lib/page-status.js
@@ -32,7 +32,7 @@ export class PageStatus extends Component {
           <div className="header-pending-panel text-small row flex-offset-1">
             <div onClick={this.pendingAction} className={loadingClass}></div>
             {this.props.transition === PAGE_STATUS_DISCONNECTED &&
-              <span>Connection to <span className="text-mono">~{this.props.usership}</span> failed</span>
+              <span>Reconnecting to <span className="text-mono">~{this.props.usership}</span></span>
             }
             {this.props.transition === PAGE_STATUS_TRANSITIONING &&
               <span>Loading page...</span>

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -25,7 +25,7 @@ export function esoo(str) {
 
 // check if hostname follows ship.*.urbit.org scheme
 export function isProxyHosted(hostName) {
-  const r = /([a-z,-]+)\.(.+\.)?urbit\.org/.exec(hostName);
+  const r = /([a-z,-]+)\.(.+\.)?arvo\.network/.exec(hostName);
   if (r && urbitOb.isValidPatp(r[1])) {
     return true;
   }
@@ -244,6 +244,15 @@ export function isDMStation(station) {
 
 export function isRootCollection(station) {
   return station.split("/")[1] === "c";
+}
+
+export function makeLocal(string) {
+	const r = /[^https|^http]?.*\.arvo\.network(.*)/.exec(string);
+	if (r) {
+		return r[1];
+	} else {
+		return string;
+	}
 }
 
 // maybe do fancier stuff later

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -107,6 +107,11 @@ class UrbitRouter {
   }
 
   registerAnchorListeners() {
+    // TODO: Commenting this out because, for whatever reason, a redirect
+    // set the metakey property on click event and would prevent this from working
+    // under certain circumstances (mostly proxied at *.arvo.network)
+    //
+    /*
     window.document.addEventListener('keydown', (e) => {
       // TODO:  Verify this works on Windows systems...
       if (e.metaKey) {
@@ -116,7 +121,9 @@ class UrbitRouter {
 
     window.document.addEventListener('keyup', (e) => {
       this.metaPressed = false;
+
     });
+    */
 
     window.document.addEventListener('click', (e) => {
       // If meta isn't currnetly held down, resolve clicks normally
@@ -129,7 +136,6 @@ class UrbitRouter {
         // If you find an "a" tag in the clicked element's parents, it's a link
         if (el && !el.attributes.disabled) {
           // We can probably do something a little nicer
-          console.log('el', el.hostname);
           if (el.hostname === "localhost" || isProxyHosted(el.hostname) || /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.exec(el.hostname)) {
             e.preventDefault();
             this.transitionTo(el.pathname + el.search);

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -129,6 +129,7 @@ class UrbitRouter {
         // If you find an "a" tag in the clicked element's parents, it's a link
         if (el && !el.attributes.disabled) {
           // We can probably do something a little nicer
+          console.log('el', el.hostname);
           if (el.hostname === "localhost" || isProxyHosted(el.hostname) || /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.exec(el.hostname)) {
             e.preventDefault();
             this.transitionTo(el.pathname + el.search);

--- a/src/js/warehouse.js
+++ b/src/js/warehouse.js
@@ -4,7 +4,6 @@ import { ConfigsReducer } from '/reducers/configs';
 import { ViewsReducer } from '/reducers/views';
 import { NamesReducer } from '/reducers/names';
 import { CirclesReducer } from '/reducers/circles';
-import { CollectionsReducer } from '/reducers/collections';
 // import { PublicReducer } from '/reducers/public';
 import { router } from '/router';
 import { PAGE_STATUS_READY, PAGE_STATUS_PROCESSING, REPORT_PAGE_STATUS, REPORT_NAVIGATE } from '/lib/constants';
@@ -86,7 +85,6 @@ class UrbitWarehouse {
     this.configsReducer = new ConfigsReducer();
     this.viewsReducer = new ViewsReducer();
     this.namesReducer = new NamesReducer();
-    this.collectionsReducer = new CollectionsReducer();
     // this.publicReducer = new PublicReducer();
     this.circlesReducer = new CirclesReducer();
 
@@ -145,7 +143,6 @@ class UrbitWarehouse {
     newReports.forEach((rep) => console.log('new report: ', rep));
     this.messagesReducer.reduce(newReports, this.store);
     this.configsReducer.reduce(newReports, this.store);
-    this.collectionsReducer.reduce(newReports, this.store);
     this.viewsReducer.reduce(newReports, this.store);
     this.namesReducer.reduce(newReports, this.store);
     this.circlesReducer.reduce(newReports, this.store);

--- a/src/js/warehouse.js
+++ b/src/js/warehouse.js
@@ -4,6 +4,7 @@ import { ConfigsReducer } from '/reducers/configs';
 import { ViewsReducer } from '/reducers/views';
 import { NamesReducer } from '/reducers/names';
 import { CirclesReducer } from '/reducers/circles';
+import { CollectionsReducer } from '/reducers/collections';
 // import { PublicReducer } from '/reducers/public';
 import { router } from '/router';
 import { PAGE_STATUS_READY, PAGE_STATUS_PROCESSING, REPORT_PAGE_STATUS, REPORT_NAVIGATE } from '/lib/constants';
@@ -85,6 +86,7 @@ class UrbitWarehouse {
     this.configsReducer = new ConfigsReducer();
     this.viewsReducer = new ViewsReducer();
     this.namesReducer = new NamesReducer();
+    this.collectionsReducer = new CollectionsReducer();
     // this.publicReducer = new PublicReducer();
     this.circlesReducer = new CirclesReducer();
 
@@ -143,6 +145,7 @@ class UrbitWarehouse {
     newReports.forEach((rep) => console.log('new report: ', rep));
     this.messagesReducer.reduce(newReports, this.store);
     this.configsReducer.reduce(newReports, this.store);
+    this.collectionsReducer.reduce(newReports, this.store);
     this.viewsReducer.reduce(newReports, this.store);
     this.namesReducer.reduce(newReports, this.store);
     this.circlesReducer.reduce(newReports, this.store);


### PR DESCRIPTION
Certain, hard to reproduce, circumstances on a proxied ship experienced full page reloads when clicking collections links.

Turns out we had a regex looking for certain hostnames in links to figure out if it was a Landscape-internal link. This regex wasn't updated when we shifted to ship.arvo.network last minute from ship.urbit.org. plz don't @ me.

This fixes that and then a follow on issue where the browser thought that a metakey was pressed when it was, objectively, not. Maybe a touchpad issue? Seemed to be related to a redirect because it only happened when user hit the bare url on a proxied ship and was redirected to /~~/landscape. Hard to say. 

I'm running this on my ship right now, so I can update if things go pear-shaped.