### PR TITLE
workaround due to firefox ignoring padding when overflow:scroll (issu…

### DIFF
--- a/src/css/pages/chat.css
+++ b/src/css/pages/chat.css
@@ -109,6 +109,16 @@ textarea.chat-input-field {
     /* use !important to prevent breakage from child margin settings */
 }
 
+/* Firefox ignores padding when using overflow:scroll */
+/* https://stackoverflow.com/questions/29986977/firefox-ignores-padding-when-using-overflowscroll */
+/* https://github.com/urbit/landscape/issues/29 */
+.chat-scrollpane-view ::after {
+  display: block;
+  height: 0px;
+  opacity: 0;
+  content: ".";  /* "" or " " doesn't work */
+}
+
 .scrollpane {
   height: 600px;
   overflow-y: scroll;


### PR DESCRIPTION
…e #29)

Addresses https://github.com/urbit/landscape/issues/29.

I tested this on Firefox, Chrome and Safari (macOS Mojave).

(I assume `src/css/pages/chat.css` gets assembled into `web/landscape/css/index.css` of the arvo repository;  I tested by editing `index.css` directly on a comet.)