### PR TITLE
fix too tall header

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -9,12 +9,7 @@
   position: relative;
 }
 
-.header-mainrow {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-}
-
-.header-carpet, .header-breadcrumbs {
+.header-breadcrumbs {
   height: 20px;
 }
 


### PR DESCRIPTION
Somehow the header got too tall, so the whole page scrolls (which it shouldn't). Here's a fix.